### PR TITLE
chore: remove InstanceInterruptionBehavior from the testing

### DIFF
--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -1,6 +1,5 @@
 import { InstanceType } from '@aws-cdk/aws-ec2';
 import * as cdk from '@aws-cdk/core';
-import { InstanceInterruptionBehavior } from './index';
 import { VpcProvider, SpotInstance } from './spot';
 
 export class IntegTesting {

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -160,7 +160,6 @@ service docker start",
           "InstanceMarketOptions": Object {
             "MarketType": "spot",
             "SpotOptions": Object {
-              "InstanceInterruptionBehavior": "stop",
               "SpotInstanceType": "persistent",
             },
           },

--- a/test/spotinstance.test.ts
+++ b/test/spotinstance.test.ts
@@ -21,8 +21,7 @@ describe('SpotInstance', () => {
         InstanceMarketOptions: {
           MarketType: 'spot',
           SpotOptions: {
-            InstanceInterruptionBehavior: 'terminate',
-            SpotInstanceType: 'one-time',
+            SpotInstanceType: 'persistent',
           },
         },
         InstanceType: 't3.large',


### PR DESCRIPTION
removed `InstanceInterruptionBehavior`