### PR TITLE
SpotOneProps.customAmiId string to IMachineImage

### DIFF
--- a/test/spotfleet.test.ts
+++ b/test/spotfleet.test.ts
@@ -25,7 +25,7 @@ describe('SpotFleet', () => {
 
   test('fleet with custom AMI ID comes with default linux userdata', () => {
     new SpotFleet(stack, 'SpotFleet', {
-      customAmiId: 'ami-xxxxxx',
+      customAmiId: ec2.MachineImage.lookup({ name: 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210429' }),
     });
     expect(stack).toHaveResourceLike('AWS::EC2::LaunchTemplate', {
       LaunchTemplateData: {


### PR DESCRIPTION
Fixes #
https://github.com/pahud/cdk-spot-one/blob/156da1fe80bf80c808a257ee614c475856dbb9e5/src/spot.ts#L279

I have problems with Ubuntu ARM like: 

```
const instance = new SpotInstance(this, 'DrupalSpot', {
			instanceInterruptionBehavior: InstanceInterruptionBehavior.STOP,
			customAmiId: ec2.MachineImage.lookup({name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210429"}), // ubuntu 20.20 arm
			defaultInstanceType: ec2.InstanceType.of(
				ec2.InstanceClass.T4G,
				ec2.InstanceSize.MICRO
			),
			vpc: defaultVpc,
			instanceRole: role,
			securityGroup: securityGroup,
			ebsVolumeSize: 16,
			additionalUserData: [fs.readFileSync('lib/DrupalSetup.sh', 'utf8')],
		});
```

Thanks.